### PR TITLE
Fixed bug in RawTemplateInjector regarding TemplateNamer

### DIFF
--- a/HandlebarsHelper/RawTemplateInjector.cs
+++ b/HandlebarsHelper/RawTemplateInjector.cs
@@ -25,7 +25,7 @@ namespace HandlebarsHelper
             templatePath = HttpContext.Current.Request.MapPath(templatePath);
             var files = FindFiles(templatePath, templatePath, templateExtensions);
 
-            return BuildTemplates(templatePath, files, new TemplateNamer());
+            return BuildTemplates(templatePath, files, templateNamer);
         }
 
         private static IHtmlString BuildTemplates(string templatePath, List<string> files, ITemplateNamer templateNamer)


### PR DESCRIPTION
Fixed a small mistake. Even when TemplateNamer is set, the default one is used. 
